### PR TITLE
Add class to body when dark mode is enabled

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -836,6 +836,11 @@ function toggleDarkMode() {
         let style = document.querySelector("#darkcss");
         style.textContent = options.dark_mode === true || options.device_dark ? css : "";
     }
+    if (options.dark_mode === true || options.device_dark) {
+        document.body.classList.add("bettercanvas--darkmode--enabled");
+    } else {
+        document.body.classList.remove("bettercanvas--darkmode--enabled");
+    }
     runiframeChecker();
 }
 
@@ -887,6 +892,7 @@ function runiframeChecker() {
         document.querySelectorAll('iframe').forEach((frame) => {
             if (frame.contentDocument && frame.contentDocument.documentElement && frame.contentDocument.documentElement.querySelector('#darkcss')) {
                 frame.contentDocument.documentElement.querySelector('#darkcss').textContent = '';
+                frame.contentDocument.body.classList.remove("bettercanvas--darkmode--enabled");
             }
         });
         return;
@@ -899,6 +905,7 @@ function runiframeChecker() {
                 const new_style_element = document.createElement("style");
                 new_style_element.textContent = generateDarkModeCSS();
                 new_style_element.id = "darkcss";
+                frame.contentDocument.body.classList.add("bettercanvas--darkmode--enabled");
                 frame.contentDocument.documentElement.prepend(new_style_element);
             }
         }


### PR DESCRIPTION
This will help plugins and other canvas extensions support Better Canvas when their changes break support for the default dark mode settings.