### PR TITLE
Fix issue #78, custom images not working in list view.

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -170,6 +170,7 @@ function applyOptionsChanges(changes) {
             case ("custom_cards_2"):
             case ("custom_cards_3"):
                 customizeCards();
+                customizeGroupingCards();
                 break;
             case ("todo_hr24"):
             case ("num_todo_items"):
@@ -243,6 +244,27 @@ function checkDashboardReady() {
                     if (!mutation.target.querySelector(".bettercanvas-todosidebar")) {
                         setupBetterTodo();
                         loadBetterTodo();
+                    }
+                } else if (mutation.target == document.querySelector('#dashboard-planner')) {
+                    // listen to dom node add when scrolling up and down
+                    const observer1 = new MutationObserver(mutations => {
+                        mutations.forEach(mutation => {
+                            if (mutation.addedNodes.length > 0) {
+                                mutation.addedNodes.forEach(addedNode => {
+                                    if (addedNode.querySelectorAll) {
+                                        let newGroupings = addedNode.querySelectorAll('.planner-grouping');
+                                        if (newGroupings.length > 0) {
+                                            customizeGroupingCards(newGroupings);
+                                        }
+                                    }
+                                });
+                            }
+                        });
+                    });
+                    // listen to dom changes
+                    const targetNode = document.querySelector('#dashboard-planner');
+                    if (targetNode) {
+                        observer1.observe(targetNode, { childList: true, subtree: true });
                     }
                 }
             }
@@ -1434,6 +1456,28 @@ function getCardId(card) {
     return -1;
 }
 
+// Get course id in list view for custom settings
+function getGroupingCardId(card) {
+    let hrefElement = card.querySelector(".Grouping-styles__heroHover");
+    if (!hrefElement || !hrefElement.href) return -1;
+
+    let id = hrefElement.href.split("courses/")[1];
+
+    // no ~
+    if (!id.includes("~")) return id;
+    // has ~ but dashboard card method is used
+    if (options["custom_cards"][id]) return id;
+
+    // weird case, some canvases replace consecutive 0s with a ~ in the id
+    // but the number of 0s isn't consistent between schools
+    id = id.split("~");
+    let re = new RegExp(`${id[0]}0+${id[1]}`);
+    for (const c of Object.keys(options["custom_cards"])) {
+        if (c.match(re)) return c;
+    }
+    return -1;
+}
+
 function customizeCards(c = null) {
     if (!options.custom_cards) return;
     try {
@@ -1500,6 +1544,37 @@ function customizeCards(c = null) {
 
         });
 
+    } catch (e) {
+        logError(e);
+    }
+}
+
+// Custom the card in list view
+function customizeGroupingCards(c = null) {
+    if (!options.custom_cards) return;
+    try {
+        let cards = c ? c : document.querySelectorAll('.Grouping-styles__heroHover');
+        if (cards.length === 0 || cards[0].querySelectorAll(".Grouping-styles__heroHover").length === 0) return;
+
+        cards.forEach(card => {
+            const id = getGroupingCardId(card);
+            let cardOptions = options["custom_cards"][id] || null;
+            if (!cardOptions) return;
+
+            if (cardOptions.img === "none") {
+                let currentImg = card.querySelector(".Grouping-styles__heroHover");
+                if (currentImg) {
+                    card.querySelector(".Grouping-styles__overlay").style.opacity = 1;
+                }
+            } else if (cardOptions.img !== "") {
+                let topColor = card.querySelector(".Grouping-styles__overlay");
+                let container = card.querySelector(".Grouping-styles__heroHover");
+                if (container) {
+                    container.style.backgroundImage = "url(\"" + cardOptions.img + "\")";
+                    topColor.style.opacity = 0.5;
+                }
+            }
+        });
     } catch (e) {
         logError(e);
     }
@@ -1805,7 +1880,7 @@ function applyAestheticChanges() {
     style.textContent = "";
     if (options.condensed_cards === true) style.textContent += ".ic-DashboardCard__header_hero {height:60px!important}.ic-DashboardCard__header-subtitle, .ic-DashboardCard__header-term{display:none}";
     if (options.remlogo === true) style.textContent += ".ic-app-header__logomark-container{display:none}";
-    if (options.disable_color_overlay === true) style.textContent += ".ic-DashboardCard__header_hero{opacity: 0!important} .ic-DashboardCard__header-button-bg{opacity: 1!important}";
+    if (options.disable_color_overlay === true) style.textContent += ".ic-DashboardCard__header_hero{opacity: 0!important} .ic-DashboardCard__header-button-bg{opacity: 1!important} .Grouping-styles__overlay{opacity: 0!important;}";
     if (options.hide_feedback === true) style.textContent += ".recent_feedback {display: none}";
     if (options.full_width === true) style.textContent += ".ic-Layout-wrapper{max-width:100%!important}";
     //if (options.full_width === true) style.textContent += ".ic-DashboardCard__link{position:absolute;top:0;left:0;max-width:100%;}.ic-DashboardCard__header_content{background:none!important;padding-top:18px;}.ic-DashboardCard{position:relative;width:333px}.bettercanvas-card-assignment{position:absolute;bottom:0;left:0;}.bettercanvas-assignment-container{background:none!important}.ic-DashboardCard__action-container{display:none}.ic-DashboardCard__header-title span{color:#fff!important;font-size:16px;margin-top:8px;}.ic-DashboardCard__header-term{display:none}";


### PR DESCRIPTION
Fix issue #78, custom images not working in list view.
Added method `customizeGroupingCards(c = null)` to customize cards in list view.
In method `checkDashboardReady()` listen to node with id `#dashboard-planner` and find class `.planner-grouping`.
Using MutationObserver to check when new `.planner-grouping` nodes add to document and call `customizeGroupingCards(c = null)` to enable changes.
Add rule `.Grouping-styles__overlay{opacity: 0!important;}` in `disable_color_overlay` to enable the color overlay function in list view.
<img width="372" alt="Screenshot 2024-09-30 at 20 19 35" src="https://github.com/user-attachments/assets/b63f95df-041d-49e7-a66f-02939f6f154a">
